### PR TITLE
Introduce major mode for code review

### DIFF
--- a/github-review.el
+++ b/github-review.el
@@ -68,6 +68,9 @@
 ;; Only repo scope needed to read PRs and submit reviews
 (defvar github-review-github-token-scopes '(repo))
 
+(defvar github-review-mode-hook nil
+  "Mode hook for `github-review-mode'.")
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;  Alist utilities to treat associative lists as immutable data structures  ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -389,7 +392,8 @@ ACC is an alist accumulating parsing state."
                      (github-review-a-get pr-alist 'num)))
   (erase-buffer)
   (insert diff)
-  (save-buffer))
+  (save-buffer)
+  (github-review-mode))
 
 (defun github-review-parsed-review-from-current-buffer ()
   "Return a code review given the current buffer containing a diff."
@@ -552,6 +556,14 @@ See ‘github-review-start’ for more information"
   "Comment on a PR (to be run from a buffer corresponding to a review)."
   (interactive)
   (github-review-submit-review "COMMENT"))
+
+;;;###autoload
+(define-derived-mode github-review-mode
+  diff-mode "Code Review"
+  "Major mode for code review"
+  (setq mode-name "Code Review")
+  (setq major-mode 'github-review-mode)
+  (run-mode-hooks 'github-review-mode-hook))
 
 (provide 'github-review)
 ;;; github-review.el ends here


### PR DESCRIPTION
#### Summary
Before this change we were using the diff mode as major mode for code
review. After this change we use the github-review-mode. For now the
diff-mode and github-review-mode behave the same (we use derived mode)
but in the future we will add new features to the github-review-mode
specific to code review.

#### Test Plan
- [x] Launched a code review and made sure that the mode is set properly and
diff mode navigation still works fine
- [x] CI