### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # github-review: GitHub code reviews with Emacs.
 
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fcharignon%2Fgithub-review&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
+
 This package contains a handful of Emacs commands to review GitHub pull request
 without leaving Emacs.
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. This can be simply added in the website also.

![Screenshot (1633)](https://user-images.githubusercontent.com/47092464/98442656-d6c83280-2140-11eb-9566-a7e1f45dec90.png)
