### PR TITLE
Reply to inline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 # Unreleased
 
+- [#81](https://github.com/charignon/github-review/pull/81): Allow reply to code comments. Enable via `github-review-reply-inline-comments`. See README.
 - [#87](https://github.com/charignon/github-review/pull/87): Enable `outline-mode` by default to allow hide/show hunks. See `outline-*` commands.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ configure the endpoint of your GitHub Enterprise installation, this should look 
   `github-review-view-comments-in-code-lines-outdated` to `t`, however we cannot
   guarantee correct placement of these comments in the review buffer.
 
+  You can also enable replies to inline comments by setting
+  `github-review-reply-inline-comments` to `t`, this feature only works if
+  `github-review-view-comments-in-code-lines` is also set to `t`. This way, if
+  you include a comment right after a previous received comment in the diff
+  buffer, your new comment will be sent as a reply.
+
 ## Notice
 
 *I am providing code in the repository to you under an open source license. Because this is my personal repository, the license you receive to my

--- a/github-review.el
+++ b/github-review.el
@@ -409,9 +409,9 @@ This function infers the PR name based on the current filename"
                                   'commit_id head-sha
                                   'event kind))
          (review (if (equal nil regular-comments)
-                     (a-assoc partial-review
-                              'comments regular-comments)
-                   partial-review)))
+                     partial-review
+                   (a-assoc partial-review
+                            'comments regular-comments))))
 
     (when (and github-review-reply-inline-comments
                reply-comments)

--- a/github-review.el
+++ b/github-review.el
@@ -71,7 +71,7 @@
 (defcustom github-review-reply-inline-comments nil
   "Flag to enable replies to inline comments.
 
-This flag will only be valid if `github-review-view-comments-in-code-lines' is set to `t`.")
+This flag will only be considered if `github-review-view-comments-in-code-lines' is set to `t`.")
 
 (defconst github-review-diffheader '(("Accept" . "application/vnd.github.v3.diff"))
   "Header for requesting diffs from GitHub.")

--- a/github-review.el
+++ b/github-review.el
@@ -341,8 +341,10 @@ ACC is an alist accumulating parsing state."
          (parsed-comments (a-get parsed-data 'comments))
          (parsed-body (s-trim-right (a-get parsed-data 'body)))
          (merged-comments (when parsed-comments (github-review-merge-comments (reverse parsed-comments)))))
-    `((body . ,parsed-body)
-      (comments . ,(reverse merged-comments)))))
+    (if (equal nil merged-comments)
+        `((body . ,parsed-body))
+      `((body . ,parsed-body)
+        (comments . ,(reverse merged-comments))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Buffer interactions ;;
@@ -614,12 +616,12 @@ Github API provides only the originalPosition in the query.")
 
     (if (not (forge-pullreq-p pullreq))
         (message "We can only review PRs at the moment. You tried on something else.")
-        (progn 
-          (setq forge-current-dir default-directory)  
-          (github-review-start-internal (a-alist  'owner   (oref repo owner)
-                                                  'repo    (oref repo name)
-                                                  'apihost (oref repo apihost)
-                                                  'num     (oref pullreq number)))))))
+      (progn
+        (setq forge-current-dir default-directory)
+        (github-review-start-internal (a-alist  'owner   (oref repo owner)
+                                                'repo    (oref repo name)
+                                                'apihost (oref repo apihost)
+                                                'num     (oref pullreq number)))))))
 
 ;;;###autoload
 (defun github-review-start (url)

--- a/github-review.el
+++ b/github-review.el
@@ -436,11 +436,13 @@ This function infers the PR name based on the current filename"
        (lambda (&rest _)
          (message "Done submitting review replies"))))
 
-    (github-review-post-review
-     pr-alist
-     review
-     (lambda (&rest _)
-       (message "Done submitting review")))))
+    (when (or regular-comments
+              (not (string-empty-p (a-get review 'body))))
+      (github-review-post-review
+       pr-alist
+       review
+       (lambda (&rest _)
+         (message "Done submitting review"))))))
 
 (defun github-review-to-comments (text)
   "Convert TEXT, a string to a string where each line is prefixed by ~."

--- a/github-review.el
+++ b/github-review.el
@@ -424,7 +424,7 @@ This function infers the PR name based on the current filename"
                                   'commit_id head-sha
                                   'event kind))
          (review (if (equal nil regular-comments)
-                     partial-review
+                     (a-dissoc partial-review 'comments)
                    (a-assoc partial-review
                             'comments regular-comments))))
 

--- a/github-review.el
+++ b/github-review.el
@@ -183,27 +183,28 @@ CALLBACK will be called back when done"
 (defun github-review-post-review-replies (pr-alist replies callback)
   "Submit replies to review comments inline."
   (deferred:$
-    (deferred:loop
-      replies
-      (lambda (comment)
-        (let-alist pr-alist
-          (let* ((path (a-get comment 'path))
-                 (position (a-get comment 'position))
-                 (comment-id (alist-get (s-concat path
-                                                  ":"
-                                                  (number-to-string position))
-                                        github-review-pos->databaseid
-                                        nil nil 'equal))
-                 (body (a-get comment 'body)))
-            (ghub-post (format "/repos/%s/%s/pulls/%s/comments/%s/replies"
-                               .owner .repo .num comment-id)
-                       nil
-                       :payload (a-alist 'body body)
-                       :headers github-review-diffheader
-                       :auth 'github-review
-                       :host (github-review-api-host pr-alist)
-                       :callback (lambda (&rest _))
-                       :errorback #'github-review-errback)))))
+    (deferred:parallel
+      (-map (lambda (comment)
+              (lambda ()
+                (let-alist pr-alist
+                  (let* ((path (a-get comment 'path))
+                         (position (a-get comment 'position))
+                         (comment-id (alist-get (s-concat path
+                                                          ":"
+                                                          (number-to-string position))
+                                                github-review-pos->databaseid
+                                                nil nil 'equal))
+                         (body (a-get comment 'body)))
+                    (ghub-post (format "/repos/%s/%s/pulls/%s/comments/%s/replies"
+                                       .owner .repo .num comment-id)
+                               nil
+                               :payload (a-alist 'body body)
+                               :headers github-review-diffheader
+                               :auth 'github-review
+                               :host (github-review-api-host pr-alist)
+                               :callback (lambda (&rest _))
+                               :errorback #'github-review-errback)))))
+            replies))
 
     (deferred:nextc it
       (lambda (x)

--- a/github-review.el
+++ b/github-review.el
@@ -225,7 +225,7 @@ CALLBACK will be called back when done"
 
 (defun github-review-previous-comment? (l)
   "Return t if L, a string, is a comment from previous review."
-  (string-prefix-p "~" l))
+  (string-prefix-p "~ " l))
 
 (defun github-review-is-start-of-file-hunk? (l)
   "Return t if L, a string that start with 'diff' marking the start of a file hunk."

--- a/test/github-review-test.el
+++ b/test/github-review-test.el
@@ -84,7 +84,8 @@ index 8ad537d..0000000
         (comments
          ((position . 5)
           (body . "Comment test")
-          (path . "bar")))))
+          (path . "bar")
+          (reply? . nil)))))
 
     (defconst example-review-deleted-comment-haskell "# comment test
 ~ remove bad
@@ -165,10 +166,12 @@ index 9eced0230..4512bb335 100644
         (comments
          ((position . 5)
           (body . "Comment test")
-          (path . "bar"))
+          (path . "bar")
+          (reply? . nil))
          ((position . 6)
           (body . "here too")
-          (path . "hledger-lib/Hledger/Reports/MultiBalanceReport.hs")))))
+          (path . "hledger-lib/Hledger/Reports/MultiBalanceReport.hs")
+          (reply? . nil)))))
 
     (defconst examplediff "# This is a global comment at the top of the file
 # with multiple
@@ -243,23 +246,28 @@ index 58baa4b..eae7707 100644
         (comments
          ((position . 1)
           (body . "comment on zeroth line\ncomment on first line")
-          (path . "content/reference/google-closure-library.adoc"))
+          (path . "content/reference/google-closure-library.adoc")
+          (reply? . nil))
          ((position . 5)
           (body . "And a comment inline about\na specific line\n```with some\ncode```")
-          (path . "content/reference/google-closure-library.adoc"))
+          (path . "content/reference/google-closure-library.adoc")
+          (reply? . nil))
          ((position . 6)
           (body . "Some other comment inline")
-          (path . "content/reference/google-closure-library.adoc")))))
+          (path . "content/reference/google-closure-library.adoc")
+          (reply? . nil)))))
 
     (defconst complex-review-expected-no-comment-on-zeroth-and-first-line
       '((body . "This is a global comment at the top of the file\nwith multiple\nlines")
         (comments
          ((position . 5)
           (body . "And a comment inline about\na specific line\n```with some\ncode```")
-          (path . "content/reference/google-closure-library.adoc"))
+          (path . "content/reference/google-closure-library.adoc")
+          (reply? . t))
          ((position . 6)
           (body . "Some other comment inline")
-          (path . "content/reference/google-closure-library.adoc")))))
+          (path . "content/reference/google-closure-library.adoc")
+          (reply? . nil)))))
 
 
     (describe "github-review-parse-review-lines"
@@ -352,7 +360,8 @@ index 58baa4b..eae7707 100644
       (before-all
         (setq github-review-comment-pos ())
         (setq github-review-view-comments-in-code-lines nil)
-        (setq github-review-view-comments-in-code-lines-outdated nil))
+        (setq github-review-view-comments-in-code-lines-outdated nil)
+        (setq github-review-reply-inline-comments nil))
       (it "can include PR comments made in code lines"
         (expect (github-review-place-review-comments example-diff-before-comments-in-code-line review-with-comments)
                 :to-equal


### PR DESCRIPTION
@charignon I had put to myself another requirement for working with PR reviews from emacs: be able to respond to comments inline. I believe this is mentioned #9 

This PR adds such functionality with a few caveats:

- Any new comment (other than in top level portion of buffer) that is *immediately* preceded by a previous comment will be treated as a reply
- I could only find a Github API that accepts single reply calls, so it may be slow or get rate limited if you have *X* number of replies. (the value of X is unknown to me)
- This only works if `github-review-view-comments-in-code-lines` is enabled.
- I tried to change as minimal as possible the current data structures used in the code, but I am afraid I cannot feature flag *everything* without a lot of duplication, if you see a way forward I am all ears :)

Give it a try 👍 