### PR TITLE
bugfix - enable outline minor mode by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change log
+
+# Unreleased
+
+- [#87](https://github.com/charignon/github-review/pull/87): Enable `outline-mode` by default to allow hide/show hunks. See `outline-*` commands.

--- a/github-review.el
+++ b/github-review.el
@@ -548,6 +548,7 @@ Github API provides only the originalPosition in the query.")
   "Major mode for code review"
   (setq mode-name "Code Review"
         major-mode 'github-review-mode)
+  (add-hook 'github-review-mode-hook #'outline-minor-mode)
   (run-mode-hooks 'github-review-mode-hook))
 
 (provide 'github-review)


### PR DESCRIPTION
This PR fix #75 , in fact this is not a bug IMHO. `diff-mode` adds a regexp to `outline-regexp` variable to enable show/hide hunks. However, this will only work if we have `outline-mode` enabled.

I think this is a good addition to have enabled by default as does not impact the performance and provides very useful features.


btw: I think would be nice to start documenting some of these changes in a changelog, wdyt?