### PR TITLE
suggestion code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ index 58baa4b..eae7707 100644
  [[try-the-wrapper-libraries-first]]
 ```
 
+You can add code suggestions by calling `github-review-suggestion-block` on top
+of the line you would like to change. Just change the code inside the suggestion box
+
+``` diff
+~ Bump lambdaisland/kaocha from 1.0.861 to 1.0.902
+~
+~
+
+diff --git a/deps.edn b/deps.edn
+index 0af375c..15c94f4 100644
+--- a/deps.edn
++++ b/deps.edn
+@@ -43,7 +43,7 @@
+
+   :test
+   {:extra-paths ["test/clj"]
+-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.861"}
++   :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.902"}
+# ```suggestion
+#    :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.9999"}
+                 kaocha-noyoda/kaocha-noyoda {:mvn/version "2019-06-03"}
+                 lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}
+                 ring/ring-mock {:mvn/version "0.4.0"}}}
+```
+
 Once done, you can submit your review with one of `github-review-approve`, `github-review-comment`, and `github-review-reject`.
 
 ## Usage with Forge

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ index 58baa4b..eae7707 100644
  [[try-the-wrapper-libraries-first]]
 ```
 
-You can add code suggestions by calling `github-review-suggestion-block` on top
+You can add code suggestions by calling `github-review-suggestion-block-at-point` on top
 of the line you would like to change. Just change the code inside the suggestion box
 
 ``` diff

--- a/github-review.el
+++ b/github-review.el
@@ -607,6 +607,19 @@ Github API provides only the originalPosition in the query.")
       (lambda (err)
         (message "Got an error from the GitHub API %S!" err)))))
 
+;;;###autoload
+(defun github-review-suggestion-block ()
+  "Open a suggestion block for the line under cursor in diff buffer."
+  (interactive)
+  (move-beginning-of-line 1)
+  (right-char 1)
+  (kill-line)
+  (yank)
+  (open-line 1)
+  (forward-line 1)
+  (insert "# ```suggestion\n# ")
+  (yank))
+
 
 ;;;###autoload
 (defun github-review-forge-pr-at-point ()

--- a/github-review.el
+++ b/github-review.el
@@ -608,7 +608,7 @@ Github API provides only the originalPosition in the query.")
         (message "Got an error from the GitHub API %S!" err)))))
 
 ;;;###autoload
-(defun github-review-suggestion-block ()
+(defun github-review-suggestion-block-at-point ()
   "Open a suggestion block for the line under cursor in diff buffer."
   (interactive)
   (move-beginning-of-line 1)


### PR DESCRIPTION
We are already able to submit suggestion code with `github-review` however a specific syntax needs to be followed. This PR adds a new public function that you can call with your cursor placed at the loc you want to suggest so it will create a suggestion box for you.

```diff
~ Bump lambdaisland/kaocha from 1.0.861 to 1.0.902
~
~

diff --git a/deps.edn b/deps.edn
index 0af375c..15c94f4 100644
--- a/deps.edn
+++ b/deps.edn
@@ -43,7 +43,7 @@

   :test
   {:extra-paths ["test/clj"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.861"}
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.902"}
# ```suggestion
#    :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.9999"}
                 kaocha-noyoda/kaocha-noyoda {:mvn/version "2019-06-03"}
                 lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}
                 ring/ring-mock {:mvn/version "0.4.0"}}}
```

turns into:

<img width="1440" alt="Screen Shot 2021-10-11 at 17 41 30" src="https://user-images.githubusercontent.com/17708295/136853161-aedfd547-764f-4df6-b188-555981c2f8d5.png">
